### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Consider using [`fusion-react`](https://github.com/fusionjs/fusion-react) instea
 #### split
 
 ```js
-import {split} from "fusion-react";
+import {split} from "fusion-react-async";
 
 const Component = split({load, LoadingComponent, ErrorComponent});
 ```


### PR DESCRIPTION
`export 'split' was not found in 'fusion-react'` 

Fix for the above error due to wrong import. split seems to be available from 'fusion-react-async'